### PR TITLE
Manually adding the PWA Install button on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "appwrite": "^16.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.24",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.460.0",
         "react": "^18.3.1",
@@ -5248,6 +5249,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -6527,6 +6555,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "appwrite": "^16.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.24",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import NoteDetailsPage from "./pages/NoteDetailsPage";
 import ProtectedPublicRoutes from "./components/ProtectedPublicRoutes";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import PwaInstallPrompt from "./components/PwaInstallPrompt";
 
 const SignUpPage = lazy(() => import("@/pages/SignUpPage"));
 const LoginPage = lazy(() => import("@/pages/LoginPage"));
@@ -148,6 +149,8 @@ function App() {
       </Routes>
 
       <ToastContainer position="top-right" autoClose={3000} />
+
+      <PwaInstallPrompt />
     </Suspense>
   );
 }

--- a/src/components/PwaInstallPrompt.tsx
+++ b/src/components/PwaInstallPrompt.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { toast } from "react-toastify";
+import { useDispatch } from "react-redux";
+import { setDeferredPrompt } from "@/store/pwa/pwaSlice";
+import { motion } from "framer-motion";
+
+export default function PwaInstallPrompt() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      e.preventDefault();
+
+      dispatch(setDeferredPrompt(e));
+
+      const hasSeen = sessionStorage.getItem("pwaInstallDismissed") || "0";
+      if (+hasSeen < 2 && /Mobi|Android/i.test(navigator.userAgent)) {
+        toast.info(<InstallToast promptEvent={e} />, {
+          position: "bottom-center",
+          autoClose: false,
+          toastId: "pwa-install",
+          closeOnClick: false,
+          draggable: false,
+        });
+        sessionStorage.setItem("pwaInstallDismissed", `${+hasSeen + 1}`);
+      }
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, [dispatch]);
+
+  return null;
+}
+
+function InstallToast({ promptEvent }: { promptEvent: any }) {
+  const handleInstall = () => {
+    promptEvent.prompt();
+    promptEvent.userChoice.then(() => {
+      sessionStorage.setItem("pwaInstallDismissed", "2");
+    });
+  };
+
+  return (
+    <motion.div
+      initial="pageInitial"
+      animate="pageAnimate"
+      exit="pageExit"
+      variants={{
+        pageInitial: { opacity: 0 },
+        pageAnimate: { opacity: 1 },
+        pageExit: { opacity: 0 },
+      }}
+      className="flex lg:hidden flex-col gap-4"
+    >
+      <span>Install this app on your device?</span>
+      <button
+        onClick={handleInstall}
+        className="bg-[#335cff] text-white py-3 px-6 rounded-lg cursor-pointer font-bold"
+      >
+        Install
+      </button>
+    </motion.div>
+  );
+}

--- a/src/store/pwa/pwaSlice.ts
+++ b/src/store/pwa/pwaSlice.ts
@@ -1,0 +1,17 @@
+// store/slices/pwaSlice.ts
+import { createSlice } from "@reduxjs/toolkit";
+
+const pwaSlice = createSlice({
+  name: "pwa",
+  initialState: {
+    deferredPrompt: null, // Store the install prompt
+  },
+  reducers: {
+    setDeferredPrompt(state, action) {
+      state.deferredPrompt = action.payload;
+    },
+  },
+});
+
+export const { setDeferredPrompt } = pwaSlice.actions;
+export default pwaSlice.reducer;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progressive Web App (PWA) installation prompts now available on mobile devices. Users can easily install the app directly from their browser for convenient offline access and home screen integration. Installation prompts appear up to twice per session to balance visibility with user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->